### PR TITLE
Fixed bug where signed responses were required

### DIFF
--- a/harica/authn-commons/pom.xml
+++ b/harica/authn-commons/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>se.sunet.edusign.harica</groupId>
     <artifactId>edusign-harica-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sunet :: eduSign :: Harica:: Authn Commons</name>

--- a/harica/authn-commons/src/main/java/se/sunet/edusign/harica/commons/SerializableCredentials.java
+++ b/harica/authn-commons/src/main/java/se/sunet/edusign/harica/commons/SerializableCredentials.java
@@ -7,8 +7,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 
 /**
- * Interface for storing serializable credential data that can recreate the credential and its ability to destroy the key
- * when reconstructed from serialized form.
+ * Interface for storing serializable credential data that can recreate the credential and its ability to destroy the
+ * key when reconstructed from serialized form.
  */
 public interface SerializableCredentials extends Serializable {
 

--- a/harica/authn-commons/src/main/java/se/sunet/edusign/harica/commons/impl/PKCS8SerializableCredentials.java
+++ b/harica/authn-commons/src/main/java/se/sunet/edusign/harica/commons/impl/PKCS8SerializableCredentials.java
@@ -24,14 +24,13 @@ import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.util.io.pem.PemWriter;
 
-import lombok.extern.slf4j.Slf4j;
 import se.sunet.edusign.harica.commons.SerializableCredentials;
 
 /**
  * Implementation of the {@link SerializableCredentials} that stores the private key as PEM formatted PKCS8 data
  */
-@Slf4j
 public class PKCS8SerializableCredentials implements SerializableCredentials {
+
   private static final long serialVersionUID = 2498510487438648389L;
 
   private static final CertificateFactory cf;
@@ -78,7 +77,8 @@ public class PKCS8SerializableCredentials implements SerializableCredentials {
   }
 
   /** {@inheritDoc} */
-  @Override public PrivateKey getPrivateKey() {
+  @Override
+  public PrivateKey getPrivateKey() {
     if (this.privateKey == null) {
       return null;
     }
@@ -91,7 +91,8 @@ public class PKCS8SerializableCredentials implements SerializableCredentials {
   }
 
   /** {@inheritDoc} */
-  @Override public PublicKey getPublicKey() {
+  @Override
+  public PublicKey getPublicKey() {
     if (this.publicKey != null) {
       try (PEMParser pemParser = new PEMParser(new StringReader(publicKey))) {
         return new JcaPEMKeyConverter().getPublicKey(getPublicKeyInfo(pemParser.readObject()));
@@ -104,12 +105,14 @@ public class PKCS8SerializableCredentials implements SerializableCredentials {
   }
 
   /** {@inheritDoc} */
-  @Override public X509Certificate getCertificate() {
+  @Override
+  public X509Certificate getCertificate() {
     return getCertificateChain().isEmpty() ? null : getCertificateChain().get(0);
   }
 
   /** {@inheritDoc} */
-  @Override public List<X509Certificate> getCertificateChain() {
+  @Override
+  public List<X509Certificate> getCertificateChain() {
     if (this.chain == null) {
       this.chain = new ArrayList<>();
     }
@@ -127,7 +130,8 @@ public class PKCS8SerializableCredentials implements SerializableCredentials {
   }
 
   /** {@inheritDoc} */
-  @Override public void setCertificateChain(List<X509Certificate> certificateChain) {
+  @Override
+  public void setCertificateChain(List<X509Certificate> certificateChain) {
     this.chain = new ArrayList<>();
     try {
       for (X509Certificate certificate : certificateChain) {
@@ -140,7 +144,8 @@ public class PKCS8SerializableCredentials implements SerializableCredentials {
   }
 
   /** {@inheritDoc} */
-  @Override public void destroy() {
+  @Override
+  public void destroy() {
     this.publicKey = null;
     this.privateKey = null;
     this.chain = null;

--- a/harica/authn-plugin/pom.xml
+++ b/harica/authn-plugin/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.sunet.edusign.harica</groupId>
     <artifactId>edusign-harica-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sunet :: eduSign :: Harica:: Authn Plugin</name>

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HaricaCAAuthenticationFactory.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HaricaCAAuthenticationFactory.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 Sweden Connect
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.config;
 
 import java.security.cert.CertificateException;
@@ -43,13 +28,7 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 
-import se.swedenconnect.security.algorithms.AlgorithmRegistrySingleton;
-import se.swedenconnect.security.credential.container.InMemoryPkiCredentialContainer;
-import se.swedenconnect.signservice.authn.AuthenticationHandler;
 import se.sunet.edusign.harica.authn.HaricaCAAuthenticationHandler;
-import se.swedenconnect.signservice.core.config.AbstractHandlerFactory;
-import se.swedenconnect.signservice.core.config.BeanLoader;
-import se.swedenconnect.signservice.core.config.HandlerConfiguration;
 import se.sunet.edusign.harica.authn.service.BackChannelRequestSigner;
 import se.sunet.edusign.harica.authn.service.CARequestConnector;
 import se.sunet.edusign.harica.authn.service.CertificateRequestFactory;
@@ -58,6 +37,12 @@ import se.sunet.edusign.harica.authn.service.UserRegistrationService;
 import se.sunet.edusign.harica.authn.service.token.ResponseParser;
 import se.sunet.edusign.harica.authn.service.token.TokenCredential;
 import se.sunet.edusign.harica.authn.service.token.TokenValidator;
+import se.swedenconnect.security.algorithms.AlgorithmRegistrySingleton;
+import se.swedenconnect.security.credential.container.InMemoryPkiCredentialContainer;
+import se.swedenconnect.signservice.authn.AuthenticationHandler;
+import se.swedenconnect.signservice.core.config.AbstractHandlerFactory;
+import se.swedenconnect.signservice.core.config.BeanLoader;
+import se.swedenconnect.signservice.core.config.HandlerConfiguration;
 
 /**
  * Base class for factories creating Harica CA authentication handlers.

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HaricaCAAuthenticationHandlerConfiguration.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HaricaCAAuthenticationHandlerConfiguration.java
@@ -1,23 +1,7 @@
-/*
- * Copyright 2022 Sweden Connect
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.config;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.cert.X509Certificate;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -33,7 +17,7 @@ import se.swedenconnect.signservice.core.config.AbstractHandlerConfiguration;
  * Base class for configuring CA authentication handlers using the Harica API.
  */
 public class HaricaCAAuthenticationHandlerConfiguration
-  extends AbstractHandlerConfiguration<AuthenticationHandler> {
+    extends AbstractHandlerConfiguration<AuthenticationHandler> {
 
   /** HTTP connect timeout in milliseconds */
   @Getter
@@ -59,7 +43,10 @@ public class HaricaCAAuthenticationHandlerConfiguration
   @Getter
   PublicKey trustedCaTokenVerificationKey;
 
-  /** URL configuration settings for this SP specifying URL end points provided by this service to communicate with the CA */
+  /**
+   * URL configuration settings for this SP specifying URL end points provided by this service to communicate with the
+   * CA
+   */
   @Getter
   SpUrlConfiguration spUrlConfiguration;
 
@@ -67,19 +54,31 @@ public class HaricaCAAuthenticationHandlerConfiguration
   @Getter
   CaConfiguration caConfiguration;
 
-  /** The name of the attribute specified in sign request as the ID of attributes used to provide the e-mail of the signer */
+  /**
+   * The name of the attribute specified in sign request as the ID of attributes used to provide the e-mail of the
+   * signer
+   */
   @Getter
   String emailAdressSource;
 
-  /** The name of the attribute specified in sign request as the ID of attributes used to provide the unique identifier of the signer */
+  /**
+   * The name of the attribute specified in sign request as the ID of attributes used to provide the unique identifier
+   * of the signer
+   */
   @Getter
   String uniqueIdentifierSource;
 
-  /** The name of the attribute specified in sign request as the ID of attributes used to provide the surname of the signer */
+  /**
+   * The name of the attribute specified in sign request as the ID of attributes used to provide the surname of the
+   * signer
+   */
   @Getter
   String surnameSource;
 
-  /** The name of the attribute specified in sign request as the ID of attributes used to provide the given name of the signer */
+  /**
+   * The name of the attribute specified in sign request as the ID of attributes used to provide the given name of the
+   * signer
+   */
   @Getter
   String givenNameSource;
 
@@ -105,17 +104,17 @@ public class HaricaCAAuthenticationHandlerConfiguration
 
   public void setRequestSigningCredential(@Nonnull final PrivateKey requestSigningCredential) {
     this.requestSigningCredential = Objects.requireNonNull(requestSigningCredential,
-      "requestSigningCredential must not be null");
+        "requestSigningCredential must not be null");
   }
 
   public void setRequestSigningAlgorithm(@Nonnull final JWSAlgorithm requestSigningAlgorithm) {
     this.requestSigningAlgorithm = Objects.requireNonNull(requestSigningAlgorithm,
-      "requestSigningAlgorithm must not be null");
+        "requestSigningAlgorithm must not be null");
   }
 
   public void setTrustedCaTokenVerificationKey(@Nonnull final PublicKey trustedCaTokenVerificationKey) {
     this.trustedCaTokenVerificationKey = Objects.requireNonNull(trustedCaTokenVerificationKey,
-      "trustedCaTokenSignerCert must not be null");
+        "trustedCaTokenSignerCert must not be null");
   }
 
   public void setEmailAdressSource(@Nullable final String emailAdressSource) {

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HttpProxyConfiguration.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/HttpProxyConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2023 Agency for Digital Government (DIGG)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.config;
 
 import lombok.Data;

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/SpUrlConfiguration.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/config/SpUrlConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 Sweden Connect
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.config;
 
 import java.util.Objects;

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/CAAuthResult.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/CAAuthResult.java
@@ -31,13 +31,15 @@ import se.swedenconnect.signservice.core.attribute.saml.impl.StringSamlIdentityA
  */
 public class CAAuthResult implements AuthenticationResult {
 
+  private static final long serialVersionUID = 4494910561079879178L;
+
   private final IdentityAssertion identityAssertion;
 
   private boolean displayedSignMessage;
 
   /**
-   * This constructor instantiates the CA Authentication result by creating an IdentityAssertion object
-   * from an issued certificate and some additional parameters
+   * This constructor instantiates the CA Authentication result by creating an IdentityAssertion object from an issued
+   * certificate and some additional parameters
    *
    * @param certificate The issued certificate
    * @param loa the level of assurance to be declared as the result LoA
@@ -47,8 +49,9 @@ public class CAAuthResult implements AuthenticationResult {
    * @throws CertificateEncodingException error parsing certificate data
    * @throws IOException invalid input
    */
-  public CAAuthResult(X509Certificate certificate, String loa, String uidAttribute, String authServiceId, boolean displayedSignMessage)
-    throws CertificateEncodingException, IOException {
+  public CAAuthResult(X509Certificate certificate, String loa, String uidAttribute, String authServiceId,
+      boolean displayedSignMessage)
+      throws CertificateEncodingException, IOException {
     this.displayedSignMessage = displayedSignMessage;
     this.identityAssertion = getAssertionFromCert(certificate, loa, uidAttribute, authServiceId);
   }
@@ -58,7 +61,8 @@ public class CAAuthResult implements AuthenticationResult {
    *
    * @return {@link IdentityAssertion}
    */
-  @Override public IdentityAssertion getAssertion() {
+  @Override
+  public IdentityAssertion getAssertion() {
     return this.identityAssertion;
   }
 
@@ -67,7 +71,8 @@ public class CAAuthResult implements AuthenticationResult {
    *
    * @return
    */
-  @Override public boolean signMessageDisplayed() {
+  @Override
+  public boolean signMessageDisplayed() {
     return displayedSignMessage;
   }
 
@@ -76,8 +81,9 @@ public class CAAuthResult implements AuthenticationResult {
    *
    * @return IdentityAssertion
    */
-  private IdentityAssertion getAssertionFromCert(X509Certificate certificate, String loa, String uidAttribute, String authServiceId)
-    throws CertificateEncodingException, IOException {
+  private IdentityAssertion getAssertionFromCert(X509Certificate certificate, String loa, String uidAttribute,
+      String authServiceId)
+      throws CertificateEncodingException, IOException {
 
     DefaultIdentityAssertion assertion = new DefaultIdentityAssertion();
     assertion.setScheme("PKI");
@@ -96,33 +102,33 @@ public class CAAuthResult implements AuthenticationResult {
    * the AuthContext extension and use its attribute mapping to locate the origin attribute names.
    */
   private List<IdentityAttribute<?>> getAttributes(X509Certificate certificate, String uidAttribute)
-    throws IOException {
+      throws IOException {
 
     List<IdentityAttribute<?>> assertionAttributes = new ArrayList<>();
     List<SubjectAttributeInfo> attributeInfoList = getAttributeInfoList(certificate.getSubjectX500Principal());
 
     addAttribute(BCStyle.SERIALNUMBER, uidAttribute,
-      "personIdentifier", attributeInfoList, assertionAttributes);
+        "personIdentifier", attributeInfoList, assertionAttributes);
     addAttribute(BCStyle.SURNAME, "urn:oid:2.5.4.4",
-      "surname", attributeInfoList, assertionAttributes);
+        "surname", attributeInfoList, assertionAttributes);
     addAttribute(BCStyle.GIVENNAME, "urn:oid:2.5.4.42",
-      "givenName", attributeInfoList, assertionAttributes);
+        "givenName", attributeInfoList, assertionAttributes);
     addAttribute(BCStyle.EmailAddress, "urn:oid:0.9.2342.19200300.100.1.3",
-      "email", attributeInfoList, assertionAttributes);
+        "email", attributeInfoList, assertionAttributes);
     addAttribute(BCStyle.CN, "urn:oid:2.16.840.1.113730.3.1.241",
-      "displayName", attributeInfoList, assertionAttributes);
+        "displayName", attributeInfoList, assertionAttributes);
     addAttribute(BCStyle.C, "urn:oid:2.5.4.6", "country", attributeInfoList, assertionAttributes);
     return assertionAttributes;
   }
 
   private void addAttribute(ASN1ObjectIdentifier certAttr, String assertionAttr, String friendlyName,
-    List<SubjectAttributeInfo> certAttrList, List<IdentityAttribute<?>> assertionAttributes) {
+      List<SubjectAttributeInfo> certAttrList, List<IdentityAttribute<?>> assertionAttributes) {
 
     Optional<SubjectAttributeInfo> certAttrOptional = certAttrList.stream()
-      .filter(subjectAttributeInfo -> subjectAttributeInfo.getOid().equals(certAttr))
-      .findFirst();
+        .filter(subjectAttributeInfo -> subjectAttributeInfo.getOid().equals(certAttr))
+        .findFirst();
     certAttrOptional.ifPresent(subjectAttributeInfo -> assertionAttributes.add(
-      new StringSamlIdentityAttribute(assertionAttr, friendlyName, subjectAttributeInfo.getValue())));
+        new StringSamlIdentityAttribute(assertionAttr, friendlyName, subjectAttributeInfo.getValue())));
   }
 
   public static List<SubjectAttributeInfo> getAttributeInfoList(X500Principal name) throws IOException {
@@ -135,7 +141,7 @@ public class CAAuthResult implements AuthenticationResult {
         for (ASN1Encodable encodable : rdnSet) {
           ASN1Sequence rdnSeq = (ASN1Sequence) encodable;
           ASN1ObjectIdentifier rdnOid = (ASN1ObjectIdentifier) rdnSeq.getObjectAt(0);
-          //String oidStr = rdnOid.getId();
+          // String oidStr = rdnOid.getId();
           ASN1Encodable rdnVal = rdnSeq.getObjectAt(1);
           String rdnValStr = getStringValue(rdnVal);
           attrInfoList.add(new SubjectAttributeInfo(rdnOid, rdnValStr));

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/OidName.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/OidName.java
@@ -1,26 +1,7 @@
-/*
- * Copyright (c) 2021. IDsec Solutions AB (IDsec)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.result;
 
 import org.bouncycastle.asn1.x509.AccessDescription;
 
-/**
- *
- * @author stefan
- */
 public enum OidName {
     cp_anyPolicy("anyPolicy", "2.5.29.32.0"),
     cp_etsiQcPubSscd("ETSI QC Public with SSCD (0.4.0.1456.1.1)", "0.4.0.1456.1.1"),
@@ -45,9 +26,8 @@ public enum OidName {
     id_pkix_ad_caRepository("caRepository","1.3.6.1.5.5.7.48.5"),
     id_pkix_ad_timestamping("timeStamping","1.3.6.1.5.5.7.48.3"),
     id_pkix_ad_caIssuers("caIssuers", AccessDescription.id_ad_caIssuers.getId()),
-    id_pkix_ad_ocsp("ocsp", AccessDescription.id_ad_ocsp.getId()),
-    ;
-    
+    id_pkix_ad_ocsp("ocsp", AccessDescription.id_ad_ocsp.getId());
+
     String name;
     String oid;
 
@@ -63,9 +43,9 @@ public enum OidName {
     public String getOid() {
         return oid;
     }
-    
-    
-    
+
+
+
     public static String getName(String oidStr){
         for (OidName oid : values()){
             if (oid.getOid().equalsIgnoreCase(oidStr)){
@@ -74,5 +54,5 @@ public enum OidName {
         }
         return oidStr;
     }
-    
+
 }

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/SubjectAttributeInfo.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/SubjectAttributeInfo.java
@@ -1,26 +1,7 @@
-/*
- * Copyright (c) 2021. IDsec Solutions AB (IDsec)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.result;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
-/**
- *
- * @author stefan
- */
 public class SubjectAttributeInfo {
     SubjectDnType type;
     ASN1ObjectIdentifier oid;
@@ -30,13 +11,13 @@ public class SubjectAttributeInfo {
     public SubjectAttributeInfo(ASN1ObjectIdentifier oid, String value) {
         this.oid = oid;
         this.value = value;
-        
+
         type = SubjectDnType.getNameTypeForOid(oid);
         if (!type.equals(SubjectDnType.unknown)){
             dispName = type.getDispName();
         } else {
             dispName = OidName.getName(oid.getId());
-        }        
+        }
     }
 
     public SubjectAttributeInfo() {
@@ -73,6 +54,6 @@ public class SubjectAttributeInfo {
     public void setValue(String value) {
         this.value = value;
     }
-    
-    
+
+
 }

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/SubjectDnType.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/result/SubjectDnType.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2021. IDsec Solutions AB (IDsec)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.authn.result;
 
 import java.nio.charset.Charset;
@@ -28,10 +13,6 @@ import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 
-/**
- *
- * @author stefan
- */
 public enum SubjectDnType {
 
     cn("Common Name","2.5.4.3"),

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/CertificateRequestResult.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/CertificateRequestResult.java
@@ -7,10 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Description
- *
- */
 @AllArgsConstructor
 @NoArgsConstructor
 @Data

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/HttpResponseData.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/HttpResponseData.java
@@ -8,7 +8,7 @@ import lombok.Getter;
  * HttpResponseData
  */
 @Getter
-public class HttpResponseData{
+public class HttpResponseData {
 
   public HttpResponseData(StatusLine statusLine, byte[] data) {
     this.statusLine = statusLine;

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/dto/CaCertificateRequest.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/dto/CaCertificateRequest.java
@@ -7,9 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Data;
 
-/**
- * Description
- */
 @Data
 public class CaCertificateRequest {
 

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/dto/CreateUserDetails.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/dto/CreateUserDetails.java
@@ -5,10 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Description
- */
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/ResponseParser.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/ResponseParser.java
@@ -18,9 +18,6 @@ import com.nimbusds.jose.Payload;
 
 import lombok.RequiredArgsConstructor;
 
-/**
- * Description
- */
 @RequiredArgsConstructor
 public class ResponseParser {
 
@@ -31,17 +28,17 @@ public class ResponseParser {
 
     CaCertificateResponse.CaCertificateResponseBuilder builder = CaCertificateResponse.builder();
 
-    Map responsemap = objectMapper.readValue(payload.toString(),
-      Map.class);
+    Map<?, ?> responsemap = objectMapper.readValue(payload.toString(),
+        Map.class);
 
-    try(PEMParser pemParser = new PEMParser(new StringReader((String)responsemap.get("certificate")))) {
-      //PemObject pemObject = pemParser.readPemObject();
+    try (PEMParser pemParser = new PEMParser(new StringReader((String) responsemap.get("certificate")))) {
+      // PemObject pemObject = pemParser.readPemObject();
       Object certObject = pemParser.readObject();
       if (certObject instanceof X509CertificateHolder) {
         builder.certificate(getCert(certObject));
       }
     }
-    try(PEMParser pemParser = new PEMParser(new StringReader((String)responsemap.get("certificate")))) {
+    try (PEMParser pemParser = new PEMParser(new StringReader((String) responsemap.get("certificate")))) {
 
       List<X509Certificate> certChain = new ArrayList<>();
       for (Object pkcs7Object = pemParser.readObject(); pkcs7Object != null; pkcs7Object = pemParser.readObject()) {
@@ -52,16 +49,17 @@ public class ResponseParser {
       builder.chain(certChain);
     }
     return builder
-      .signatureId((String) responsemap.get("signatureId"))
-      .uniqueIdentifier((String) responsemap.get("uniqueIdentifier"))
-      .build();
+        .signatureId((String) responsemap.get("signatureId"))
+        .uniqueIdentifier((String) responsemap.get("uniqueIdentifier"))
+        .build();
   }
 
   private X509Certificate getCert(Object certHolderObj) throws CertificateException {
-    try{
+    try {
       return (X509Certificate) certificateFactory.generateCertificate(
-        new ByteArrayInputStream(((X509CertificateHolder) certHolderObj).getEncoded()));
-    } catch (IOException ex) {
+          new ByteArrayInputStream(((X509CertificateHolder) certHolderObj).getEncoded()));
+    }
+    catch (IOException ex) {
       throw new CertificateException("Unable to parse certificate holder object");
     }
   }

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenCredential.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenCredential.java
@@ -46,11 +46,11 @@ public class TokenCredential {
   }
 
   public TokenCredential(PublicKey publicKey, String kid) {
-    this (null, publicKey, null, kid);
+    this(null, publicKey, null, kid);
   }
 
   public TokenCredential(PublicKey publicKey) {
-    this (null, publicKey, null, null);
+    this(null, publicKey, null, null);
   }
 
   private static byte[] getThumbprint(X509Certificate certificate) {

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenValidationException.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenValidationException.java
@@ -1,7 +1,5 @@
 package se.sunet.edusign.harica.authn.service.token;
 
-import java.io.Serial;
-
 import com.nimbusds.jwt.SignedJWT;
 
 import lombok.Getter;
@@ -11,9 +9,10 @@ import lombok.Getter;
  */
 public class TokenValidationException extends Exception {
 
-  @Getter private final SignedJWT signedJWT;
-
   private static final long serialVersionUID = -6908586099690472926L;
+
+  @Getter
+  private final SignedJWT signedJWT;
 
   /** {@inheritDoc} */
   public TokenValidationException(String message, SignedJWT signedJWT) {

--- a/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenValidator.java
+++ b/harica/authn-plugin/src/main/java/se/sunet/edusign/harica/authn/service/token/TokenValidator.java
@@ -14,12 +14,6 @@ import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
 
-import lombok.extern.slf4j.Slf4j;
-
-/**
- * Description
- */
-@Slf4j
 public class TokenValidator {
 
   private final TokenCredential trustedCredential;
@@ -54,7 +48,7 @@ public class TokenValidator {
   }
 
   private JWSVerifier getVerifier(SignedJWT signedJWT)
-    throws TokenValidationException, CertificateEncodingException, NoSuchAlgorithmException, JOSEException {
+      throws TokenValidationException, CertificateEncodingException, NoSuchAlgorithmException, JOSEException {
 
     JWSHeader header = signedJWT.getHeader();
 
@@ -65,7 +59,7 @@ public class TokenValidator {
     PublicKey publicKey = trustedCredential.getPublicKey();
     if (publicKey == null) {
       throw new TokenValidationException(
-        "No trusted public key matches the Id token JWT header declarations", signedJWT);
+          "No trusted public key matches the Id token JWT header declarations", signedJWT);
     }
 
     if (publicKey instanceof ECPublicKey) {
@@ -73,6 +67,5 @@ public class TokenValidator {
     }
     return new RSASSAVerifier((RSAPublicKey) publicKey);
   }
-
 
 }

--- a/harica/cert-plugin/pom.xml
+++ b/harica/cert-plugin/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.sunet.edusign.harica</groupId>
     <artifactId>edusign-harica-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sunet :: eduSign :: Harica:: KeyAndCert Plugin</name>
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>se.swedenconnect.signservice</groupId>
       <artifactId>signservice-keycert-base</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>se.sunet.edusign.harica</groupId>

--- a/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/HaricaCAKeyAndCertificateHandler.java
+++ b/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/HaricaCAKeyAndCertificateHandler.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
+import se.sunet.edusign.harica.commons.SerializableCredentials;
 import se.swedenconnect.security.credential.BasicCredential;
 import se.swedenconnect.security.credential.PkiCredential;
 import se.swedenconnect.signservice.authn.IdentityAssertion;
@@ -14,14 +15,13 @@ import se.swedenconnect.signservice.context.SignServiceContext;
 import se.swedenconnect.signservice.core.AbstractSignServiceHandler;
 import se.swedenconnect.signservice.core.types.InvalidRequestException;
 import se.swedenconnect.signservice.protocol.SignRequestMessage;
-import se.sunet.edusign.harica.commons.SerializableCredentials;
 
 /**
- * Provide the sign service credentials based on completed authentication and certificate issuance using the
- * Harica CA API.
+ * Provide the sign service credentials based on completed authentication and certificate issuance using the Harica CA
+ * API.
  */
 public class HaricaCAKeyAndCertificateHandler extends AbstractSignServiceHandler
-  implements KeyAndCertificateHandler {
+    implements KeyAndCertificateHandler {
 
   /** Prefix for all context values that we store/retrieve. */
   public static final String PREFIX = "se.swedenconnect.signservice.harica";
@@ -35,17 +35,20 @@ public class HaricaCAKeyAndCertificateHandler extends AbstractSignServiceHandler
   public HaricaCAKeyAndCertificateHandler() {
   }
 
-  @Override public void checkRequirements(@Nonnull SignRequestMessage signRequestMessage,
-    @Nonnull SignServiceContext context) throws InvalidRequestException {
+  @Override
+  public void checkRequirements(@Nonnull SignRequestMessage signRequestMessage,
+      @Nonnull SignServiceContext context) throws InvalidRequestException {
     // No checks to be made
   }
 
-  @Nonnull @Override public PkiCredential generateSigningCredential(@Nonnull SignRequestMessage signRequestMessage,
-    @Nonnull IdentityAssertion identityAssertion, @Nonnull SignServiceContext context)
-    throws KeyException, CertificateException {
+  @Nonnull
+  @Override
+  public PkiCredential generateSigningCredential(@Nonnull SignRequestMessage signRequestMessage,
+      @Nonnull IdentityAssertion identityAssertion, @Nonnull SignServiceContext context)
+      throws KeyException, CertificateException {
 
     SerializableCredentials serializableCredentials = Objects.requireNonNull(context.get(SIGNER_CREDENTIAL_KEY),
-      "Session stored signing credentials must not be null");
+        "Session stored signing credentials must not be null");
 
     if (serializableCredentials.getCertificate() == null) {
       throw new CertificateException("No signer certificate is available");
@@ -54,7 +57,7 @@ public class HaricaCAKeyAndCertificateHandler extends AbstractSignServiceHandler
       throw new CertificateException("No signer certificate chain is available");
     }
     PkiCredential pkiCredential = new BasicCredential(serializableCredentials.getCertificateChain(),
-      serializableCredentials.getPrivateKey());
+        serializableCredentials.getPrivateKey());
     serializableCredentials.destroy();
     context.remove(SIGNER_CREDENTIAL_KEY);
     return pkiCredential;

--- a/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/HaricaKeyAndCertificateHandlerConfiguration.java
+++ b/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/HaricaKeyAndCertificateHandlerConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 Sweden Connect
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.certificate.config;
 
 import javax.annotation.Nonnull;

--- a/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/HaricaKeyAndCertificateHandlerFactory.java
+++ b/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/HaricaKeyAndCertificateHandlerFactory.java
@@ -1,24 +1,8 @@
-/*
- * Copyright 2022 Sweden Connect
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package se.sunet.edusign.harica.certificate.config;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import lombok.extern.slf4j.Slf4j;
 import se.sunet.edusign.harica.certificate.HaricaCAKeyAndCertificateHandler;
 import se.swedenconnect.signservice.certificate.KeyAndCertificateHandler;
 import se.swedenconnect.signservice.core.config.AbstractHandlerFactory;
@@ -28,20 +12,18 @@ import se.swedenconnect.signservice.core.config.HandlerConfiguration;
 /**
  * Factory for creating {@link HaricaCAKeyAndCertificateHandler} instances.
  */
-@Slf4j
 public class HaricaKeyAndCertificateHandlerFactory extends AbstractHandlerFactory<KeyAndCertificateHandler> {
 
-
-  @Nonnull @Override protected KeyAndCertificateHandler createHandler(
-    @Nullable HandlerConfiguration<KeyAndCertificateHandler> configuration, @Nullable BeanLoader beanLoader)
-    throws IllegalArgumentException {
+  @Nonnull
+  @Override
+  protected KeyAndCertificateHandler createHandler(
+      @Nullable HandlerConfiguration<KeyAndCertificateHandler> configuration, @Nullable BeanLoader beanLoader)
+      throws IllegalArgumentException {
 
     if (!HaricaKeyAndCertificateHandlerConfiguration.class.isInstance(configuration)) {
       throw new IllegalArgumentException(
-        "Unknown configuration object supplied - " + configuration.getClass().getSimpleName());
+          "Unknown configuration object supplied - " + configuration.getClass().getSimpleName());
     }
-    final HaricaKeyAndCertificateHandlerConfiguration conf =
-      HaricaKeyAndCertificateHandlerConfiguration.class.cast(configuration);
 
     return this.createHandler();
   }
@@ -50,7 +32,8 @@ public class HaricaKeyAndCertificateHandlerFactory extends AbstractHandlerFactor
     return new HaricaCAKeyAndCertificateHandler();
   }
 
-  @Override protected Class<KeyAndCertificateHandler> getHandlerType() {
+  @Override
+  protected Class<KeyAndCertificateHandler> getHandlerType() {
     return KeyAndCertificateHandler.class;
   }
 

--- a/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/spring/CAKeyAndCertHandlerBeanConfiguration.java
+++ b/harica/cert-plugin/src/main/java/se/sunet/edusign/harica/certificate/config/spring/CAKeyAndCertHandlerBeanConfiguration.java
@@ -8,7 +8,7 @@ import se.sunet.edusign.harica.certificate.config.HaricaKeyAndCertificateHandler
 import se.sunet.edusign.harica.certificate.config.HaricaKeyAndCertificateHandlerFactory;
 
 /**
- * Spring @Configuration class for providing the {@link HaricaCAKeyAndCertificateHandler} as a bean
+ * Spring Configuration class for providing the {@link HaricaCAKeyAndCertificateHandler} as a bean
  */
 @Configuration
 public class CAKeyAndCertHandlerBeanConfiguration {

--- a/harica/pom.xml
+++ b/harica/pom.xml
@@ -6,12 +6,11 @@
   <groupId>se.sunet.edusign.harica</groupId>
   <artifactId>edusign-harica-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0</version>
 
   <parent>
     <groupId>se.sunet.edusign</groupId>
     <artifactId>edusign-signservice-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sunet :: eduSign :: Harica :: Plugins parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.sunet.edusign</groupId>
   <artifactId>edusign-signservice-parent</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Sunet :: eduSign</name>

--- a/saml-plugin/pom.xml
+++ b/saml-plugin/pom.xml
@@ -4,12 +4,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>edusign-saml-plugin</artifactId>
-  <packaging>jar</packaging>
+  <packaging>jar</packaging>  
 
   <parent>
     <groupId>se.sunet.edusign</groupId>
     <artifactId>edusign-signservice-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sunet :: eduSign :: SAML Plugin</name>

--- a/saml-plugin/src/main/java/se/sunet/edusign/saml/SwamidSamlAuthenticationHandlerFactory.java
+++ b/saml-plugin/src/main/java/se/sunet/edusign/saml/SwamidSamlAuthenticationHandlerFactory.java
@@ -7,6 +7,7 @@ import se.swedenconnect.opensaml.saml2.response.ResponseProcessor;
 import se.swedenconnect.signservice.authn.AuthenticationHandler;
 import se.swedenconnect.signservice.authn.saml.config.SamlAuthenticationHandlerConfiguration;
 import se.swedenconnect.signservice.authn.saml.config.SamlAuthenticationHandlerFactory;
+import se.swedenconnect.signservice.core.config.BeanLoader;
 
 /**
  * A factory for creating {@link SwamidSamlAuthenticationHandler} instances.
@@ -49,6 +50,23 @@ public class SwamidSamlAuthenticationHandlerFactory extends SamlAuthenticationHa
       return super.createHandler(config, metadataProvider, entityDescriptorContainer, responseProcessor,
           authnRequestGenerator, preferredRequestBinding);
     }
+  }
+
+  /**
+   * Asserts that we require signed assertions ...
+   */
+  @Override
+  protected ResponseProcessor createResponseProcessor(final SamlAuthenticationHandlerConfiguration config,
+      final BeanLoader beanLoader, final MetadataProvider metadataProvider) {
+
+    if (config.getRequireSignedAssertions() == null) {
+      config.setRequireSignedAssertions(true);
+    }
+    if (config.getRequireSignedAssertions() != null && !config.getRequireEncryptedAssertions().booleanValue()) {
+      throw new IllegalArgumentException("require-signed-assertions is set to false - this is not allowed for Swamid");
+    }
+
+    return super.createResponseProcessor(config, beanLoader, metadataProvider);
   }
 
 }

--- a/signservice-app/pom.xml
+++ b/signservice-app/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.sunet.edusign</groupId>
     <artifactId>edusign-signservice-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>  
 
   <name>Sunet :: eduSign :: SignService Application</name>

--- a/signservice-app/src/main/resources/application-sandbox.yml
+++ b/signservice-app/src/main/resources/application-sandbox.yml
@@ -201,7 +201,7 @@ signservice:
             key-password: secret
         sign-authn-requests: true
         require-encrypted-assertions: false
-        require-signed-assertions: false
+        require-signed-assertions: true
         message-replay-checker-ref: signservice.MessageReplayChecker
         metadata:
           entity-categories:


### PR DESCRIPTION
Fixed bug where signed responses were required.

Now. The setting `authn.saml.require-signed-assertions` must be set to true.
